### PR TITLE
feat: add mongo pagination param decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Content-Range: data 300-399/1015
 Link: </data?page=1&per_page=100>; rel="first", </data?page=11&per_page=100>; rel="last", </data?page=5&per_page=100>; rel="next", </data?page=3&per_page=100>; rel="prev"
 ```
 
-If you use MongoDB as your database, we also provide `ParamDecorator` you can use to convert the request to a mongo query parameter.
+If you use MongoDB as your database, we also provide a `ParamDecorator` you can use to convert the request to a mongo query parameter.
 ```typescript
 import { LinkHeaderInterceptor, MongoPaginationParamDecorator, MongoPagination } from '@algoan/nestjs-pagination';
 import { Controller, Get, UseInterceptors } from '@nestjs/common';

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Import `LinkHeaderInterceptor` next to a controller method.
 
 ```typescript
 import { LinkHeaderInterceptor } from '@algoan/nestjs-pagination';
-import { Controller, Get, UserInterceptors } from '@nestjs/common';
+import { Controller, Get, UseInterceptors } from '@nestjs/common';
 
 @Controller()
 /**
@@ -66,4 +66,28 @@ For instance, if you have 1015 resources, calling `GET /data?page=4&per_page=100
 ```
 Content-Range: data 300-399/1015
 Link: </data?page=1&per_page=100>; rel="first", </data?page=11&per_page=100>; rel="last", </data?page=5&per_page=100>; rel="next", </data?page=3&per_page=100>; rel="prev"
+```
+
+If you use MongoDB as your database, we also provide `ParamDecorator` you can use to convert the request to a mongo query parameter.
+```typescript
+import { LinkHeaderInterceptor, MongoPaginationParamDecorator, MongoPagination } from '@algoan/nestjs-pagination';
+import { Controller, Get, UseInterceptors } from '@nestjs/common';
+
+@Controller()
+/**
+ * Controller returning a lot of documents
+ */
+class AppController {
+  /**
+   * Find all documents
+   */
+  @UseInterceptors(new LinkHeaderInterceptor('data'))
+  @Get('/data')
+  public async findAll(@MongoPaginationParamDecorator() pagination: MongoPagination ): Promise<{ totalDocs: number; resource: DataToReturn[] }> {
+    const data: DataToReturn = await model.find(pagination);
+    const count: number = await model.count(pagination.filter)
+
+    return { totalDocs: count, resource: data };
+  }
+}
 ```

--- a/src/add-link-header.interceptor.ts
+++ b/src/add-link-header.interceptor.ts
@@ -9,7 +9,7 @@ import { map } from 'rxjs/operators';
  * Response extends from Express
  */
 export interface Response<T> extends ExpressResponse {
-  data: Data<T>
+  data: Data<T>;
 }
 
 /**
@@ -36,7 +36,6 @@ interface LinkOptions {
  */
 @Injectable()
 export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
-
   constructor(private readonly resource: string) {}
 
   /**
@@ -70,12 +69,15 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
         /**
          * Set Content-Range header
          */
-        response.setHeader('Content-Range', this.buildContentRangeHeader({
-          page,
-          limit,
-          resourceUrl,
-          totalDocs: data.totalDocs,
-        }));
+        response.setHeader(
+          'Content-Range',
+          this.buildContentRangeHeader({
+            page,
+            limit,
+            resourceUrl,
+            totalDocs: data.totalDocs,
+          }),
+        );
 
         return data.resource;
       }),
@@ -165,6 +167,6 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
       last: endIndex - 1,
       length: linkOptions.totalDocs,
       unit: this.resource,
-    })
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { LinkHeaderInterceptor, Response } from './add-link-header.interceptor';
-export { MongoPaginationParamDecorator } from './mongo-pagination-param.decorator';
+export { MongoPaginationParamDecorator, MongoPagination } from './mongo-pagination-param.decorator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-import { LinkHeaderInterceptor, Response } from './add-link-header.interceptor';
-
-export { LinkHeaderInterceptor, Response };
+export { LinkHeaderInterceptor, Response } from './add-link-header.interceptor';
+export { MongoPaginationParamDecorator } from './mongo-pagination-param.decorator';

--- a/src/mongo-pagination-param.decorator.ts
+++ b/src/mongo-pagination-param.decorator.ts
@@ -7,7 +7,7 @@ const DEFAULT_NUMBER_OF_RESULTS: number = 10;
 /**
  * Mongo query
  */
-export interface MongoQuery {
+export interface MongoPagination {
   filter: {};
   limit: number;
   skip: number;
@@ -16,7 +16,7 @@ export interface MongoQuery {
 
 // tslint:disable-next-line:variable-name
 export const MongoPaginationParamDecorator: () => ParameterDecorator = createParamDecorator(
-  (_data: {}, req: Request): MongoQuery => {
+  (_data: {}, req: Request): MongoPagination => {
     const page: number = Number(req.query.page) || FIRST_PAGE;
     const limit: number = Number(req.query.per_page) || DEFAULT_NUMBER_OF_RESULTS;
     let filter: {};

--- a/src/mongo-pagination-param.decorator.ts
+++ b/src/mongo-pagination-param.decorator.ts
@@ -1,0 +1,39 @@
+import { BadRequestException, createParamDecorator } from '@nestjs/common';
+import { Request } from 'express';
+
+const FIRST_PAGE: number = 1;
+const DEFAULT_NUMBER_OF_RESULTS: number = 10;
+
+/**
+ * Mongo query
+ */
+export interface MongoQuery {
+  filter: {};
+  limit: number;
+  skip: number;
+  sort: [];
+}
+
+// tslint:disable-next-line:variable-name
+export const MongoPaginationParamDecorator: () => ParameterDecorator = createParamDecorator(
+  (_data: {}, req: Request): MongoQuery => {
+    const page: number = Number(req.query.page) || FIRST_PAGE;
+    const limit: number = Number(req.query.per_page) || DEFAULT_NUMBER_OF_RESULTS;
+    let filter: {};
+    let sort: [];
+
+    try {
+      filter = req.query.filter !== undefined ? JSON.parse(req.query.filter) : {};
+      sort = req.query.sort !== undefined ? JSON.parse(req.query.sort) : [];
+    } catch (exception) {
+      throw new BadRequestException();
+    }
+
+    return {
+      filter,
+      limit,
+      skip: (page - 1) * limit,
+      sort,
+    };
+  },
+);

--- a/src/mongo-pagination-param.decorator.ts
+++ b/src/mongo-pagination-param.decorator.ts
@@ -26,7 +26,7 @@ export const MongoPaginationParamDecorator: () => ParameterDecorator = createPar
       filter = req.query.filter !== undefined ? JSON.parse(req.query.filter) : {};
       sort = req.query.sort !== undefined ? JSON.parse(req.query.sort) : [];
     } catch (exception) {
-      throw new BadRequestException();
+      throw new BadRequestException('The sort or filter parameter cannot be parsed');
     }
 
     return {

--- a/test/add-link-header.test.ts
+++ b/test/add-link-header.test.ts
@@ -14,7 +14,6 @@ describe('Tests related to the Link Header interceptor', () => {
   });
 
   describe('Tests with a limit of 100', () => {
-
     it('AD01 - should successfully add Link in headers without params', async () => {
       const res: request.Response = await request(app.getHttpServer())
         .get('/data')
@@ -38,7 +37,7 @@ describe('Tests related to the Link Header interceptor', () => {
           page: '2',
           per_page: '100',
           rel: 'next',
-        }
+        },
       };
 
       expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
@@ -53,38 +52,38 @@ describe('Tests related to the Link Header interceptor', () => {
         .get('/data?page=4&per_page=100')
         .expect(200);
 
-        const expectedResult: formatLinkHeader.Links = {
-          first: {
-            url: '/data?page=1&per_page=100',
-            page: '1',
-            per_page: '100',
-            rel: 'first',
-          },
-          last: {
-            url: '/data?page=11&per_page=100',
-            page: '11',
-            per_page: '100',
-            rel: 'last',
-          },
-          next: {
-            url: '/data?page=5&per_page=100',
-            page: '5',
-            per_page: '100',
-            rel: 'next',
-          },
-          prev: {
-            url: '/data?page=3&per_page=100',
-            page: '3',
-            per_page: '100',
-            rel: 'prev',
-          }
-        };
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data?page=1&per_page=100',
+          page: '1',
+          per_page: '100',
+          rel: 'first',
+        },
+        last: {
+          url: '/data?page=11&per_page=100',
+          page: '11',
+          per_page: '100',
+          rel: 'last',
+        },
+        next: {
+          url: '/data?page=5&per_page=100',
+          page: '5',
+          per_page: '100',
+          rel: 'next',
+        },
+        prev: {
+          url: '/data?page=3&per_page=100',
+          page: '3',
+          per_page: '100',
+          rel: 'prev',
+        },
+      };
 
-        expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-        expect(res.header['content-range']).to.equal('data 300-399/1015');
-        expect(res.body.totalDocs).to.be.undefined;
-        expect(res.body.resource).to.be.undefined;
-        expect(res.body).to.be.an('array');
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 300-399/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
     });
 
     it('AD03 - should successfully add Link in headers for the last page', async () => {
@@ -92,74 +91,73 @@ describe('Tests related to the Link Header interceptor', () => {
         .get('/data?page=11&per_page=100')
         .expect(200);
 
-        const expectedResult: formatLinkHeader.Links = {
-          first: {
-            url: '/data?page=1&per_page=100',
-            page: '1',
-            per_page: '100',
-            rel: 'first',
-          },
-          last: {
-            url: '/data?page=11&per_page=100',
-            page: '11',
-            per_page: '100',
-            rel: 'last',
-          },
-          prev: {
-            url: '/data?page=10&per_page=100',
-            page: '10',
-            per_page: '100',
-            rel: 'prev',
-          }
-        };
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data?page=1&per_page=100',
+          page: '1',
+          per_page: '100',
+          rel: 'first',
+        },
+        last: {
+          url: '/data?page=11&per_page=100',
+          page: '11',
+          per_page: '100',
+          rel: 'last',
+        },
+        prev: {
+          url: '/data?page=10&per_page=100',
+          page: '10',
+          per_page: '100',
+          rel: 'prev',
+        },
+      };
 
-        expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-        expect(res.header['content-range']).to.equal('data 1000-1015/1015');
-        expect(res.body.totalDocs).to.be.undefined;
-        expect(res.body.resource).to.be.undefined;
-        expect(res.body).to.be.an('array');
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 1000-1015/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
     });
   });
 
   describe('Tests with a limit of 25', () => {
-
     it('AD10 - should successfully add Link in headers with params', async () => {
       const res: request.Response = await request(app.getHttpServer())
         .get('/data?page=4&per_page=25')
         .expect(200);
 
-        const expectedResult: formatLinkHeader.Links = {
-          first: {
-            url: '/data?page=1&per_page=25',
-            page: '1',
-            per_page: '25',
-            rel: 'first',
-          },
-          last: {
-            url: '/data?page=41&per_page=25',
-            page: '41',
-            per_page: '25',
-            rel: 'last',
-          },
-          next: {
-            url: '/data?page=5&per_page=25',
-            page: '5',
-            per_page: '25',
-            rel: 'next',
-          },
-          prev: {
-            url: '/data?page=3&per_page=25',
-            page: '3',
-            per_page: '25',
-            rel: 'prev',
-          }
-        };
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data?page=1&per_page=25',
+          page: '1',
+          per_page: '25',
+          rel: 'first',
+        },
+        last: {
+          url: '/data?page=41&per_page=25',
+          page: '41',
+          per_page: '25',
+          rel: 'last',
+        },
+        next: {
+          url: '/data?page=5&per_page=25',
+          page: '5',
+          per_page: '25',
+          rel: 'next',
+        },
+        prev: {
+          url: '/data?page=3&per_page=25',
+          page: '3',
+          per_page: '25',
+          rel: 'prev',
+        },
+      };
 
-        expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-        expect(res.header['content-range']).to.equal('data 75-99/1015');
-        expect(res.body.totalDocs).to.be.undefined;
-        expect(res.body.resource).to.be.undefined;
-        expect(res.body).to.be.an('array');
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 75-99/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
     });
 
     it('AD11 - should successfully add Link in headers for the last page', async () => {
@@ -167,32 +165,32 @@ describe('Tests related to the Link Header interceptor', () => {
         .get('/data?page=41&per_page=25')
         .expect(200);
 
-        const expectedResult: formatLinkHeader.Links = {
-          first: {
-            url: '/data?page=1&per_page=25',
-            page: '1',
-            per_page: '25',
-            rel: 'first',
-          },
-          last: {
-            url: '/data?page=41&per_page=25',
-            page: '41',
-            per_page: '25',
-            rel: 'last',
-          },
-          prev: {
-            url: '/data?page=40&per_page=25',
-            page: '40',
-            per_page: '25',
-            rel: 'prev',
-          }
-        };
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data?page=1&per_page=25',
+          page: '1',
+          per_page: '25',
+          rel: 'first',
+        },
+        last: {
+          url: '/data?page=41&per_page=25',
+          page: '41',
+          per_page: '25',
+          rel: 'last',
+        },
+        prev: {
+          url: '/data?page=40&per_page=25',
+          page: '40',
+          per_page: '25',
+          rel: 'prev',
+        },
+      };
 
-        expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-        expect(res.header['content-range']).to.equal('data 1000-1015/1015');
-        expect(res.body.totalDocs).to.be.undefined;
-        expect(res.body.resource).to.be.undefined;
-        expect(res.body).to.be.an('array');
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 1000-1015/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
     });
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, INestApplication, Module, UseInterceptors } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { CustomParamFactory } from '@nestjs/common/interfaces/features/custom-route-param-factory.interface';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { LinkHeaderInterceptor } from '../src';
@@ -53,4 +55,28 @@ export async function createTestAppModule(): Promise<INestApplication> {
   }).compile();
 
   return moduleFixture.createNestApplication();
+}
+
+export function getParamDecoratorFactory(decorator: Function): CustomParamFactory {
+  /**
+   * Test class
+   */
+  // tslint:disable-next-line:max-classes-per-file
+  class TestClass {
+    /**
+     * Test method
+     */
+    public test(@decorator() _value: {}): void {
+      return;
+    }
+  }
+
+  // tslint:disable-next-line:completed-docs
+  const metadata: { [key: string]: { factory: CustomParamFactory } } = Reflect.getMetadata(
+    ROUTE_ARGS_METADATA,
+    TestClass,
+    'test',
+  );
+
+  return metadata[Object.keys(metadata)[0]].factory;
 }

--- a/test/mongo-pagination-param.test.ts
+++ b/test/mongo-pagination-param.test.ts
@@ -2,11 +2,11 @@ import { BadRequestException } from '@nestjs/common';
 import { expect } from 'chai';
 import { Request } from 'express';
 import { MongoPaginationParamDecorator } from '../src';
-import { MongoQuery } from '../src/mongo-pagination-param.decorator';
+import { MongoPagination } from '../src/mongo-pagination-param.decorator';
 import { getParamDecoratorFactory } from './helpers';
 
 describe('Tests related to the MongoPagination ParamDecorator', () => {
-  let factory: (_data: {}, req: Request) => MongoQuery;
+  let factory: (_data: {}, req: Request) => MongoPagination;
 
   before(() => {
     factory = getParamDecoratorFactory(MongoPaginationParamDecorator);
@@ -15,7 +15,7 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
   it('MPPD01 - should successfully return default value on empty query', () => {
     const req: {} = { query: {} };
 
-    const result: MongoQuery = factory({}, req as Request);
+    const result: MongoPagination = factory({}, req as Request);
 
     expect(result).to.deep.equal({
       filter: {},
@@ -28,7 +28,7 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
   it('MPPD02 - should successfully handle another page', () => {
     const req: {} = { query: { page: '2', per_page: '20' } };
 
-    const result: MongoQuery = factory({}, req as Request);
+    const result: MongoPagination = factory({}, req as Request);
 
     expect(result).to.deep.equal({
       filter: {},
@@ -41,7 +41,7 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
   it('MPPD03 - should successfully parse filters', () => {
     const req: {} = { query: { page: '1', per_page: '20', filter: '{"key": "value"}', sort: '[]' } };
 
-    const result: MongoQuery = factory({}, req as Request);
+    const result: MongoPagination = factory({}, req as Request);
 
     expect(result).to.deep.equal({
       filter: { key: 'value' },

--- a/test/mongo-pagination-param.test.ts
+++ b/test/mongo-pagination-param.test.ts
@@ -1,0 +1,59 @@
+import { BadRequestException } from '@nestjs/common';
+import { expect } from 'chai';
+import { Request } from 'express';
+import { MongoPaginationParamDecorator } from '../src';
+import { MongoQuery } from '../src/mongo-pagination-param.decorator';
+import { getParamDecoratorFactory } from './helpers';
+
+describe('Tests related to the MongoPagination ParamDecorator', () => {
+  let factory: (_data: {}, req: Request) => MongoQuery;
+
+  before(() => {
+    factory = getParamDecoratorFactory(MongoPaginationParamDecorator);
+  });
+
+  it('MPPD01 - should successfully return default value on empty query', () => {
+    const req: {} = { query: {} };
+
+    const result: MongoQuery = factory({}, req as Request);
+
+    expect(result).to.deep.equal({
+      filter: {},
+      limit: 10,
+      skip: 0,
+      sort: [],
+    });
+  });
+
+  it('MPPD02 - should successfully handle another page', () => {
+    const req: {} = { query: { page: '2', per_page: '20' } };
+
+    const result: MongoQuery = factory({}, req as Request);
+
+    expect(result).to.deep.equal({
+      filter: {},
+      limit: 20,
+      skip: 20,
+      sort: [],
+    });
+  });
+
+  it('MPPD03 - should successfully parse filters', () => {
+    const req: {} = { query: { page: '1', per_page: '20', filter: '{"key": "value"}', sort: '[]' } };
+
+    const result: MongoQuery = factory({}, req as Request);
+
+    expect(result).to.deep.equal({
+      filter: { key: 'value' },
+      limit: 20,
+      skip: 0,
+      sort: [],
+    });
+  });
+
+  it('MPPD04 - should throw bad request exception on parse error', () => {
+    const req: {} = { query: { filter: '{invalidJson}' } };
+
+    expect(() => factory({}, req as Request)).to.throw(BadRequestException);
+  });
+});


### PR DESCRIPTION
Hello,

I added a new param decorator to parse the request object and return a mongo compatible mongo query.

## Example
This query parameter:
```js
{ page: '1', per_page: '20', filter: '{"key": "value"}', sort: '[]' }
```
Will generate this mongo query:
```js
{
  filter: { key: 'value' },
  limit: 20,
  skip: 0,
  sort: [],
}
```

Thanks!