### PR TITLE
feat: add configuration object to interceptor and decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # NestJS Request Pagination
 
-A simple NestJS interceptor catching `page` and `per_page` query parameters and format a Link Header, based on [GitHub](https://developer.github.com/v3/guides/traversing-with-pagination/) pagination API.
+A simple NestJS interceptor catching query parameters and format a Link Header, based on [GitHub](https://developer.github.com/v3/guides/traversing-with-pagination/) pagination API.
 This module uses [format-link-header](https://github.com/jonathansamines/format-link-header) node module to build the response Link Header.
 
 ## Installation
@@ -50,11 +50,11 @@ class AppController {
   /**
    * Find all documents
    */
-  @UseInterceptors(new LinkHeaderInterceptor('data'))
+  @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data' }))
   @Get('/data')
   public async findAll(): Promise<{ totalDocs: number; resource: DataToReturn[] }> {
     const data: DataToReturn = await model.find(...);
-    const count: number = await model.count()
+    const count: number = await model.count();
 
     return { totalDocs: count, resource: data };
   }
@@ -81,13 +81,24 @@ class AppController {
   /**
    * Find all documents
    */
-  @UseInterceptors(new LinkHeaderInterceptor('data'))
+  @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data' }))
   @Get('/data')
   public async findAll(@MongoPaginationParamDecorator() pagination: MongoPagination ): Promise<{ totalDocs: number; resource: DataToReturn[] }> {
     const data: DataToReturn = await model.find(pagination);
-    const count: number = await model.count(pagination.filter)
+    const count: number = await model.count(pagination.filter);
 
     return { totalDocs: count, resource: data };
   }
 }
+```
+
+## Usage
+
+By default, the interceptor and the decorator will look for the query parameters `page` and  `per_page`. 
+You can also change the name of those parameters if you want, by passing a configuration object. Beware that if you use both the interceptor and the decorator, you need to pass the configuration to both of them.
+
+```typescript
+new LinkHeaderInterceptor({ resource: 'data', pageName: '_page', perPageName: 'numberPerPage' })
+
+@MongoPaginationParamDecorator({ pageName: '_page', perPageName: 'numberPerPage' })
 ```

--- a/src/mongo-pagination-param.decorator.ts
+++ b/src/mongo-pagination-param.decorator.ts
@@ -16,9 +16,12 @@ export interface MongoPagination {
 
 // tslint:disable-next-line:variable-name
 export const MongoPaginationParamDecorator: () => ParameterDecorator = createParamDecorator(
-  (_data: {}, req: Request): MongoPagination => {
-    const page: number = Number(req.query.page) || FIRST_PAGE;
-    const limit: number = Number(req.query.per_page) || DEFAULT_NUMBER_OF_RESULTS;
+  (
+    { pageName = 'page', perPageName = 'per_page' }: { pageName?: string; perPageName?: string } = {},
+    req: Request,
+  ): MongoPagination => {
+    const page: number = Number(req.query[pageName]) || FIRST_PAGE;
+    const limit: number = Number(req.query[perPageName]) || DEFAULT_NUMBER_OF_RESULTS;
     let filter: {};
     let sort: [];
 

--- a/test/add-link-header.test.ts
+++ b/test/add-link-header.test.ts
@@ -193,4 +193,45 @@ describe('Tests related to the Link Header interceptor', () => {
       expect(res.body).to.be.an('array');
     });
   });
+
+  describe('Tests with custom configuration', () => {
+    it('AD12 - should successfully handle custom query parameters', async () => {
+      const res: request.Response = await request(app.getHttpServer())
+        .get('/data-custom-query?_page=41&numberPerPage=25')
+        .expect(200);
+
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data-custom-query?_page=1&numberPerPage=25',
+          page: '1',
+          per_page: '25',
+          _page: '1',
+          numberPerPage: '25',
+          rel: 'first',
+        },
+        last: {
+          url: '/data-custom-query?_page=41&numberPerPage=25',
+          page: '41',
+          per_page: '25',
+          _page: '41',
+          numberPerPage: '25',
+          rel: 'last',
+        },
+        prev: {
+          url: '/data-custom-query?_page=40&numberPerPage=25',
+          page: '40',
+          per_page: '25',
+          _page: '40',
+          numberPerPage: '25',
+          rel: 'prev',
+        },
+      };
+
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data-custom-query 1000-1015/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
+    });
+  });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -25,7 +25,7 @@ class FakeAppController {
   /**
    * Find all documents
    */
-  @UseInterceptors(new LinkHeaderInterceptor('data'))
+  @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data' }))
   @Get('/data')
   public async findAll(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
     const data: FakeDataToReturn[] = [];
@@ -36,6 +36,17 @@ class FakeAppController {
     }
 
     return { totalDocs: data.length, resource: data };
+  }
+
+  /**
+   * Find all documents
+   */
+  @UseInterceptors(
+    new LinkHeaderInterceptor({ resource: 'data-custom-query', pageName: '_page', perPageName: 'numberPerPage' }),
+  )
+  @Get('/data-custom-query')
+  public async findAllWithCustomQuery(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
+    return this.findAll();
   }
 }
 

--- a/test/mongo-pagination-param.test.ts
+++ b/test/mongo-pagination-param.test.ts
@@ -6,7 +6,8 @@ import { MongoPagination } from '../src/mongo-pagination-param.decorator';
 import { getParamDecoratorFactory } from './helpers';
 
 describe('Tests related to the MongoPagination ParamDecorator', () => {
-  let factory: (_data: {}, req: Request) => MongoPagination;
+  // @ts-ignore
+  let factory: (_data?: {}, req: Request) => MongoPagination;
 
   before(() => {
     factory = getParamDecoratorFactory(MongoPaginationParamDecorator);
@@ -15,7 +16,7 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
   it('MPPD01 - should successfully return default value on empty query', () => {
     const req: {} = { query: {} };
 
-    const result: MongoPagination = factory({}, req as Request);
+    const result: MongoPagination = factory(undefined, req as Request);
 
     expect(result).to.deep.equal({
       filter: {},
@@ -55,5 +56,18 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
     const req: {} = { query: { filter: '{invalidJson}' } };
 
     expect(() => factory({}, req as Request)).to.throw(BadRequestException);
+  });
+
+  it('MPPD05 - should handle custom query params name', () => {
+    const req: {} = { query: { _page: '1', _per_page: '20', filter: '{"key": "value"}', sort: '[]' } };
+
+    const result: MongoPagination = factory({ pageName: '_page', perPageName: '_per_page' }, req as Request);
+
+    expect(result).to.deep.equal({
+      filter: { key: 'value' },
+      limit: 20,
+      skip: 0,
+      sort: [],
+    });
   });
 });


### PR DESCRIPTION
I added the ability to configure the query parameters used by the interceptor and decorator. For now, this configuration is not linked between the two to prevent coupling them.

BREAKING CHANGE: Interceptor now accepts an option object as constructor argument instead of anonymous argument

Here's the new usage:
```typescript
new LinkHeaderInterceptor({ resource: 'data', pageName: '_page', perPageName: 'numberPerPage' })
@MongoPaginationParamDecorator({ pageName: '_page', perPageName: 'numberPerPage' })
```
Those options are optional and have default values. 